### PR TITLE
Create header component with navigation buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,16 @@
+import React from 'react'
+
+import { Container } from '@mui/material'
+import Header from './components/Common/Header'
 
 export default function App() {
 	return (
-		<div style={{ padding: 24, fontFamily: 'Roboto, sans-serif' }}>
-			<h1>MoHUA Dashboard</h1>
-			<p>Project scaffold is working.</p>
+		<div style={{ fontFamily: 'Roboto, sans-serif' }}>
+			<Header />
+			<Container sx={{ py: 3 }}>
+				<h1>MoHUA Dashboard</h1>
+				<p>Project scaffold is working.</p>
+			</Container>
 		</div>
 	)
 }

--- a/src/components/Common/Header.tsx
+++ b/src/components/Common/Header.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react'
+import { AppBar, Toolbar, Typography, Box, Button, Stack } from '@mui/material'
+
+type ProgramKey = 'DSP' | 'C&D' | 'MRS'
+
+const PROGRAMS: ProgramKey[] = ['DSP', 'C&D', 'MRS']
+
+export default function Header() {
+	const [selected, setSelected] = useState<ProgramKey>('DSP')
+
+	return (
+<AppBar position="static" color="transparent" elevation={0} sx={{ borderBottom: '1px solid rgba(0,0,0,0.08)' }}>
+	<Toolbar sx={{ display: 'flex', justifyContent: 'space-between', gap: 2, py: 1.5 }}>
+		<Typography variant="h6" sx={{ fontWeight: 700, color: '#000' }}>MoHUA</Typography>
+		<Box>
+			<Stack direction="row" spacing={2}>
+				{PROGRAMS.map((key) => {
+					const isSelected = selected === key
+					return (
+						<Button
+							key={key}
+							variant="contained"
+							onClick={() => setSelected(key)}
+							sx={{
+								textTransform: 'none',
+								fontWeight: 700,
+								px: 3,
+								py: 1,
+								borderRadius: 1.5,
+								transition: 'transform 80ms ease, box-shadow 120ms ease, background-color 120ms ease',
+								backgroundColor: isSelected ? '#4CAF50' : '#e0e0e0',
+								color: isSelected ? '#fff' : '#000',
+
+								// 3D effect
+								boxShadow: isSelected
+									? '0 6px 0 #2e7d32, 0 6px 12px rgba(0,0,0,0.2)'
+									: '0 6px 0 #9e9e9e, 0 6px 12px rgba(0,0,0,0.12)',
+								'&:hover': {
+									backgroundColor: isSelected ? '#43A047' : '#d5d5d5'
+								},
+								'&:active': {
+									transform: 'translateY(2px)',
+									boxShadow: isSelected
+										? '0 4px 0 #2e7d32, 0 4px 8px rgba(0,0,0,0.2)'
+										: '0 4px 0 #9e9e9e, 0 4px 8px rgba(0,0,0,0.12)'
+								}
+							}}
+						>
+							{key}
+						</Button>
+					)
+				})}
+			</Stack>
+		</Box>
+	</Toolbar>
+</AppBar>
+	)
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import { StrictMode } from 'react'
+import React, { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "esModuleInterop": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx",
+    "jsx": "react",
+    "types": ["react", "react-dom"],
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
Add the `Header` component with interactive 3D buttons.

This PR implements the specified header section, including 'MoHUA' text and three clickable buttons ('DSP', 'C&D', 'MRS') that display a 3D effect and change color when selected. It also includes necessary configuration adjustments to `tsconfig.json` and `src/main.tsx` to resolve JSX runtime compatibility issues with the project setup, ensuring the application builds and runs correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6b7af82-c884-4feb-9edb-1ead206a8269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e6b7af82-c884-4feb-9edb-1ead206a8269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

