### PR TITLE
Prevent navigation on button click

### DIFF
--- a/src/components/Common/Header.tsx
+++ b/src/components/Common/Header.tsx
@@ -72,7 +72,11 @@ const Header: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const handleNavigation = (path: string) => {
+  const handleNavigation = (path: string, event?: React.MouseEvent) => {
+    if (event) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
     navigate(path);
   };
 
@@ -97,20 +101,23 @@ const Header: React.FC = () => {
         
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
           <StyledButton
+            type="button"
             selected={isSelected('/dsp')}
-            onClick={() => handleNavigation('/dsp')}
+            onClick={(e) => handleNavigation('/dsp', e)}
           >
             DSP
           </StyledButton>
           <StyledButton
+            type="button"
             selected={isSelected('/cd')}
-            onClick={() => handleNavigation('/cd')}
+            onClick={(e) => handleNavigation('/cd', e)}
           >
             C&D
           </StyledButton>
           <StyledButton
+            type="button"
             selected={isSelected('/mrs')}
-            onClick={() => handleNavigation('/mrs')}
+            onClick={(e) => handleNavigation('/mrs', e)}
           >
             MRS
           </StyledButton>


### PR DESCRIPTION
Prevent C&D and MRS buttons from causing full page reloads by adding `type="button"` and stopping default event propagation.

---
<a href="https://cursor.com/background-agent?bcId=bc-2dbcb8cb-21e0-4714-8331-bad161b8e776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2dbcb8cb-21e0-4714-8331-bad161b8e776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

