### PR TITLE
Reduce dsp tile height by 50%

### DIFF
--- a/src/pages/DSP/CityTiles.tsx
+++ b/src/pages/DSP/CityTiles.tsx
@@ -41,7 +41,7 @@ const getResolutionStatus = (percentage: number): 'Satisfactory' | 'Average' | '
 
 // Styled components
 const CityTileCard = styled(Card)<{ resolutionColor: string }>(({ resolutionColor }) => ({
-  height: '100%',
+  height: '50%',
   borderRadius: '20px',
   transition: 'all 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
   cursor: 'pointer',


### PR DESCRIPTION
Reduce the DSP tile height by 50% as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-55600be2-f70f-44df-b8cc-5d516d2c9f06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-55600be2-f70f-44df-b8cc-5d516d2c9f06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

