### PR TITLE
Build: exclude test files from TypeScript project

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,14 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/__tests__/**",
+    "vitest.setup.ts",
+    "src/test-utils.tsx"
+  ],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
- Add exclude globs for tests and setup files to tsconfig
- Prevent Vercel `tsc` step from compiling test files