### PR TITLE
Highlight city names on tiles

### DIFF
--- a/src/pages/DSP/CityTiles.tsx
+++ b/src/pages/DSP/CityTiles.tsx
@@ -325,13 +325,18 @@ const CityTile: React.FC<CityTileProps> = ({ city, onMoreInfo }) => {
               <Typography 
                 variant="h6" 
                 sx={{ 
-                  fontWeight: 700,
+                  fontWeight: 900,
                   color: '#ffffff',
-                  fontSize: '1.2rem',
+                  fontSize: '1.5rem',
                   lineHeight: 1.2,
                   flex: 1,
                   pr: 1,
-                  textShadow: '0 2px 4px rgba(0,0,0,0.3)',
+                  textShadow: '0 3px 8px rgba(0,0,0,0.5), 0 0 20px rgba(255,255,255,0.3)',
+                  letterSpacing: '0.5px',
+                  background: 'linear-gradient(180deg, rgba(255,255,255,0.12) 0%, rgba(255,255,255,0.04) 100%)',
+                  padding: '8px 12px',
+                  borderRadius: '8px',
+                  border: '1px solid rgba(255,255,255,0.15)',
                 }}
               >
                 {city.cityName}


### PR DESCRIPTION
Increase the visual prominence of city names on city tiles to improve readability and quick identification.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4eacb77-0b77-497f-a7cc-16d67e3a8e55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c4eacb77-0b77-497f-a7cc-16d67e3a8e55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

