### PR TITLE
Adjust gauge chart color contrast

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,6 @@
 export const DSP_COLORS = {
   SATISFACTORY: '#4CAF50', // Green - >=90%
-  AVERAGE: '#FFC107',      // Amber - 50-89%
+  AVERAGE: '#FFD54F',      // Lighter Amber - 50-89%
   UNSATISFACTORY: '#F44336', // Red - <50%
   RAISED: '#0E1525',       // Deep night for raised/target bars
 };


### PR DESCRIPTION
Lighten the yellow/amber color for average status gauge charts to reduce visual prominence.

---
<a href="https://cursor.com/background-agent?bcId=bc-c72df739-6814-4898-a83b-46163d69491c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c72df739-6814-4898-a83b-46163d69491c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

