### PR TITLE
Change performance text to white

### DIFF
--- a/src/pages/DSP/CityTiles.tsx
+++ b/src/pages/DSP/CityTiles.tsx
@@ -272,7 +272,7 @@ const ConsolidatedGaugeChart: React.FC<{
           flexDirection: 'column',
           pointerEvents: 'none'
         }}>
-          <Typography variant="h4" sx={{ color: '#111827', fontWeight: 800, textShadow: '0 2px 4px rgba(0,0,0,0.08)' }}>
+          <Typography variant="h4" sx={{ color: '#ffffff', fontWeight: 800, textShadow: '0 2px 4px rgba(0,0,0,0.08)' }}>
             {resolutionRate.toFixed(1)}%
           </Typography>
           <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.85)' }}>


### PR DESCRIPTION
Change the color of the "76.3%" text to white to improve visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-62960870-d29f-4904-a2d6-f15ac748f4a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-62960870-d29f-4904-a2d6-f15ac748f4a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

