### PR TITLE
Restore ministry of housing header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,7 @@ const ComingSoonPage = ({ title, subtitle }: { title: string; subtitle: string }
             textShadow: '0 4px 8px rgba(0,0,0,0.3)',
           }}
         >
-          MoHUA
+          Ministry of Housing & Urban Affairs
         </Typography>
         <Box sx={{ flex: 1, textAlign: 'center', marginX: 4 }}>
           <Typography

--- a/src/components/Common/Header.tsx
+++ b/src/components/Common/Header.tsx
@@ -102,6 +102,18 @@ const Header: React.FC = () => {
             alt="Government of India Logo"
             sx={{ height: 40, width: 'auto', mr: 2 }}
           />
+          <Typography
+            variant="h6"
+            component="div"
+            sx={{
+              color: '#ffffff',
+              fontWeight: 700,
+              letterSpacing: '0.5px',
+              textShadow: '0 1px 2px rgba(0,0,0,0.25)'
+            }}
+          >
+            Ministry of Housing & Urban Affairs
+          </Typography>
           {/* Keep abbreviation for tests without displaying it */}
           <Typography sx={{ display: 'none' }}>MoHUA</Typography>
         </Box>


### PR DESCRIPTION
Restore "Ministry of Housing & Urban Affairs" to the header and coming soon page.

The user requested to revert a previous change that removed the full ministry name from the header, preferring it to be displayed as it was before.

---
<a href="https://cursor.com/background-agent?bcId=bc-03ea2999-52c7-484d-bc6d-88faa9f699b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-03ea2999-52c7-484d-bc6d-88faa9f699b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

