### PR TITLE
Add percentage labels to gauge charts

### DIFF
--- a/src/pages/LandingPage/HeroSection.tsx
+++ b/src/pages/LandingPage/HeroSection.tsx
@@ -222,6 +222,18 @@ const LeaderboardTile: React.FC<LeaderboardTileProps> = ({ city }) => {
           <CircularProgressIndicator percentage={city.value} color={color} />
         </Box>
 
+        {/* Gauge label just below the chart */}
+        <Typography
+          variant="caption"
+          sx={{ color: 'rgba(255, 255, 255, 0.85)', textAlign: 'center', display: 'block', mb: 1 }}
+        >
+          {city.program === 'DSP'
+            ? 'Percentage of Resolution'
+            : city.program === 'C&D'
+            ? 'Percentage of Target Achieved'
+            : 'Percentage of Target achieved'}
+        </Typography>
+
         {/* Footer with metric info and status badge */}
         <Box
           sx={{


### PR DESCRIPTION
Add specific percentage labels below gauge charts on DSP, C&D, and MRS tiles to meet display requirements.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1f424e5-6c54-41ca-b3a8-daf400eff33c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c1f424e5-6c54-41ca-b3a8-daf400eff33c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

