### PR TITLE
Add landing page theme toggle

### DIFF
--- a/src/components/Common/Header.tsx
+++ b/src/components/Common/Header.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { AppBar, Toolbar, Typography, Button, Box, ButtonProps } from '@mui/material';
+import { AppBar, Toolbar, Typography, Button, Box, ButtonProps, IconButton } from '@mui/material';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { styled } from '@mui/material/styles';
+import { styled, useTheme } from '@mui/material/styles';
+import DarkModeIcon from '@mui/icons-material/DarkMode';
+import LightModeIcon from '@mui/icons-material/LightMode';
 
 interface NavButtonProps extends ButtonProps {
   selected?: boolean;
@@ -68,6 +70,7 @@ const StyledButton = styled((props: NavButtonProps) => {
 const Header: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const theme = useTheme();
 
   const handleNavigation = (path: string, event?: React.MouseEvent) => {
     if (event) {
@@ -140,6 +143,13 @@ const Header: React.FC = () => {
           >
             MRS
           </StyledButton>
+          <IconButton
+            aria-label="toggle theme"
+            onClick={() => window.dispatchEvent(new Event('toggle-color-mode'))}
+            sx={{ ml: 1, color: '#ffffff' }}
+          >
+            {theme.palette.mode === 'dark' ? <LightModeIcon /> : <DarkModeIcon />}
+          </IconButton>
         </Box>
       </Toolbar>
     </AppBar>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,31 +5,40 @@ import { ThemeProvider, createTheme } from '@mui/material/styles'
 import CssBaseline from '@mui/material/CssBaseline'
 import App from './App'
 
-const theme = createTheme({
+type ThemeMode = 'light' | 'dark'
+
+const getDesignTokens = (mode: ThemeMode) => ({
   palette: {
+    mode,
     primary: {
-      // Soft sky blue accent inspired by iOS Weather
       main: '#7aa2ff',
     },
     secondary: {
-      // Warm sunrise amber for highlights
       main: '#FFD166',
     },
     error: {
       main: '#FF6B6B',
     },
-    background: {
-      // Night-sky background
-      default: '#0B1220',
-      paper: '#0F1B2A',
-    },
-    text: {
-      primary: '#E6EDF3',
-      secondary: '#B0B7C3',
-    },
+    background: mode === 'dark'
+      ? {
+          default: '#0B1220',
+          paper: '#0F1B2A',
+        }
+      : {
+          default: '#F8FAFF',
+          paper: '#FFFFFF',
+        },
+    text: mode === 'dark'
+      ? {
+          primary: '#E6EDF3',
+          secondary: '#B0B7C3',
+        }
+      : {
+          primary: '#111827',
+          secondary: '#4B5563',
+        },
   },
   typography: {
-    // Prefer San Francisco on Apple devices, fall back to system UI/fonts elsewhere
     fontFamily:
       '"SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, "Noto Sans", sans-serif',
     h1: {
@@ -61,13 +70,43 @@ if (!rootElement) {
   throw new Error('Root element not found');
 }
 
-ReactDOM.createRoot(rootElement).render(
-  <React.StrictMode>
+const getInitialMode = (): ThemeMode => {
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('color-mode');
+    if (stored === 'light' || stored === 'dark') return stored;
+  }
+  return 'dark';
+}
+
+function Root() {
+  const [mode, setMode] = React.useState<ThemeMode>(getInitialMode);
+
+  React.useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('color-mode', mode);
+    }
+  }, [mode]);
+
+  React.useEffect(() => {
+    const handler = () => setMode((prev) => (prev === 'light' ? 'dark' : 'light'));
+    window.addEventListener('toggle-color-mode', handler);
+    return () => window.removeEventListener('toggle-color-mode', handler);
+  }, []);
+
+  const theme = React.useMemo(() => createTheme(getDesignTokens(mode)), [mode]);
+
+  return (
     <BrowserRouter>
       <ThemeProvider theme={theme}>
         <CssBaseline />
         <App />
       </ThemeProvider>
     </BrowserRouter>
+  );
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <Root />
   </React.StrictMode>,
 )

--- a/src/pages/LandingPage/LandingPage.tsx
+++ b/src/pages/LandingPage/LandingPage.tsx
@@ -7,9 +7,12 @@ import StatsOverview from './StatsOverview';
 const LandingPage: React.FC = () => {
   return (
     <Box
-      sx={{
+      sx={(theme) => ({
         minHeight: '100vh',
-        background: 'linear-gradient(180deg, #0B1220 0%, #0F1B2A 100%)',
+        background:
+          theme.palette.mode === 'dark'
+            ? 'linear-gradient(180deg, #0B1220 0%, #0F1B2A 100%)'
+            : 'linear-gradient(180deg, #F8FAFF 0%, #FFFFFF 100%)',
         position: 'relative',
         '&::before': {
           content: '""',
@@ -19,10 +22,12 @@ const LandingPage: React.FC = () => {
           right: 0,
           bottom: 0,
           background:
-            'radial-gradient(1000px 400px at 20% 0%, rgba(122,162,255,0.15) 0%, rgba(122,162,255,0) 60%), radial-gradient(800px 300px at 80% 10%, rgba(255,209,102,0.12) 0%, rgba(255,209,102,0) 60%)',
+            theme.palette.mode === 'dark'
+              ? 'radial-gradient(1000px 400px at 20% 0%, rgba(122,162,255,0.15) 0%, rgba(122,162,255,0) 60%), radial-gradient(800px 300px at 80% 10%, rgba(255,209,102,0.12) 0%, rgba(255,209,102,0) 60%)'
+              : 'radial-gradient(1000px 400px at 20% 0%, rgba(122,162,255,0.20) 0%, rgba(122,162,255,0) 60%), radial-gradient(800px 300px at 80% 10%, rgba(255,209,102,0.16) 0%, rgba(255,209,102,0) 60%)',
           pointerEvents: 'none',
         },
-      }}
+      })}
     >
       <Header />
       <HeroSection />


### PR DESCRIPTION
Add a theme toggle button to the header to switch between light and dark modes, persisting the user's preference.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b4c7b2a-87cb-41e7-9b8a-32e4ad229ec4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b4c7b2a-87cb-41e7-9b8a-32e4ad229ec4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

