### PR TITLE
Update landing page tile names

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -24,21 +24,21 @@ export const DSP_CATEGORIES = [
 export const MOCK_LEADING_CITIES = [
   {
     id: '1',
-    name: 'Mumbai',
+    name: 'Delhi',
     value: 95.2,
     metric: 'Resolution %',
     program: 'DSP' as const
   },
   {
     id: '2',
-    name: 'Delhi',
+    name: 'Ghaziabad',
     value: 87.5,
     metric: 'Achievement %',
     program: 'C&D' as const
   },
   {
     id: '3',
-    name: 'Noida',
+    name: 'Gurgaon',
     value: 92.8,
     metric: 'Road Coverage %',
     program: 'MRS' as const


### PR DESCRIPTION
Update landing page tile city names to Delhi, Ghaziabad, and Gurgaon as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-762ede0b-ddc3-497c-9cd3-178e4ab5b6ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-762ede0b-ddc3-497c-9cd3-178e4ab5b6ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

