### PR TITLE
Remove chart footer text

### DIFF
--- a/src/pages/LandingPage/StatsOverview.tsx
+++ b/src/pages/LandingPage/StatsOverview.tsx
@@ -191,10 +191,7 @@ const DSPSection: React.FC<{ data: DSPComplaintData[] }> = ({ data }) => {
     resolvedUnsatisfactory: item.status === 'Unsatisfactory' ? item.resolved : 0,
   }));
 
-  // Totals computed from provided city data
-  const totalRaised = data.reduce((sum, item) => sum + item.raised, 0);
-  const totalResolved = data.reduce((sum, item) => sum + item.resolved, 0);
-  const overallResolutionRate = totalRaised > 0 ? (totalResolved / totalRaised) * 100 : 0;
+  
 
   return (
     <Card sx={{ height: '100%', backgroundColor: 'background.paper' }}>
@@ -220,15 +217,7 @@ const DSPSection: React.FC<{ data: DSPComplaintData[] }> = ({ data }) => {
           </ResponsiveContainer>
         </Box>
 
-        {/* Totals summary based on provided city data */}
-        <Box sx={{ mt: 2, p: 1.25, borderRadius: '8px', bgcolor: 'action.hover' }}>
-          <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
-            Totals (DSP)
-          </Typography>
-          <Typography variant="caption" color="text.secondary">
-            Raised: {totalRaised.toLocaleString()} | Resolved: {totalResolved.toLocaleString()} | Resolution Rate: {overallResolutionRate.toFixed(2)}%
-          </Typography>
-        </Box>
+        
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
Remove the "Totals (DSP)" footer from the DSP chart section and its associated unused variables.

---
<a href="https://cursor.com/background-agent?bcId=bc-19399198-1e3a-489e-ade3-ee2c33a2c373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-19399198-1e3a-489e-ade3-ee2c33a2c373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

