### PR TITLE
Design sleek landing page charts with expand option

### DIFF
--- a/src/pages/LandingPage/Charts/ChartCard.tsx
+++ b/src/pages/LandingPage/Charts/ChartCard.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Card, CardContent, Box, Typography, IconButton, Tooltip } from '@mui/material';
+import OpenInFullIcon from '@mui/icons-material/OpenInFull';
+
+export interface ChartCardProps {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+  onExpand?: () => void;
+}
+
+const ChartCard: React.FC<ChartCardProps> = ({ title, subtitle, children, onExpand }) => {
+  return (
+    <Card sx={{ height: '100%', backgroundColor: 'background.paper', position: 'relative' }}>
+      <CardContent sx={{ pr: 1.5 }}>
+        <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', mb: 1 }}>
+          <Box>
+            <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold', mb: 0 }}>
+              {title}
+            </Typography>
+            {subtitle && (
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 0.25 }}>
+                {subtitle}
+              </Typography>
+            )}
+          </Box>
+          {onExpand && (
+            <Tooltip title="Expand">
+              <IconButton size="small" aria-label="expand chart" onClick={onExpand} sx={{ mt: -0.5 }}>
+                <OpenInFullIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          )}
+        </Box>
+        {children}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ChartCard;

--- a/src/pages/LandingPage/Charts/ExpandChartDialog.tsx
+++ b/src/pages/LandingPage/Charts/ExpandChartDialog.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  IconButton,
+  Box,
+  Button,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import DownloadIcon from '@mui/icons-material/Download';
+
+export type LabelMode = 'percent' | 'absolute';
+
+export interface ExpandChartDialogProps {
+  open: boolean;
+  title: string;
+  onClose: () => void;
+  onExportCSV?: () => void;
+  onExportPNG?: () => void;
+  labelMode: LabelMode;
+  onLabelModeChange: (mode: LabelMode) => void;
+  children: React.ReactNode;
+  contentRef?: React.RefObject<HTMLDivElement>;
+}
+
+const ExpandChartDialog: React.FC<ExpandChartDialogProps> = ({
+  open,
+  title,
+  onClose,
+  onExportCSV,
+  onExportPNG,
+  labelMode,
+  onLabelModeChange,
+  children,
+  contentRef,
+}) => {
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="lg" aria-labelledby="expanded-chart-title">
+      <DialogTitle id="expanded-chart-title" sx={{ pr: 6 }}>
+        {title}
+        <IconButton onClick={onClose} aria-label="close" sx={{ position: 'absolute', right: 8, top: 8 }}>
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers sx={{ bgcolor: 'background.default' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2, gap: 2, flexWrap: 'wrap' }}>
+          <ToggleButtonGroup
+            size="small"
+            value={labelMode}
+            exclusive
+            onChange={(_, v) => v && onLabelModeChange(v)}
+            aria-label="Label mode"
+          >
+            <ToggleButton value="percent" aria-label="percentage labels">% Labels</ToggleButton>
+            <ToggleButton value="absolute" aria-label="absolute labels">Absolute</ToggleButton>
+          </ToggleButtonGroup>
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            {onExportCSV && (
+              <Tooltip title="Download CSV">
+                <Button size="small" variant="outlined" startIcon={<DownloadIcon />} onClick={onExportCSV}>CSV</Button>
+              </Tooltip>
+            )}
+            {onExportPNG && (
+              <Tooltip title="Download PNG">
+                <Button size="small" variant="outlined" startIcon={<DownloadIcon />} onClick={onExportPNG}>PNG</Button>
+              </Tooltip>
+            )}
+          </Box>
+        </Box>
+        <Box ref={contentRef} sx={{ height: 460 }}>
+          {children}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} variant="contained">Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ExpandChartDialog;

--- a/src/pages/LandingPage/Charts/ExpandedBarChart.tsx
+++ b/src/pages/LandingPage/Charts/ExpandedBarChart.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, LabelList, Cell } from 'recharts';
+import { DSP_COLORS } from '../../../utils/constants';
+import type { LabelMode } from './ExpandChartDialog';
+
+export interface ExpandedBarDatum {
+  city: string;
+  raisedOrTarget: number; // base/black
+  actualOrResolved: number; // colored
+  percentage: number;
+  status: 'Satisfactory' | 'Average' | 'Unsatisfactory';
+}
+
+export interface ExpandedBarChartProps {
+  data: ExpandedBarDatum[];
+  labelMode: LabelMode;
+}
+
+const getColor = (status: ExpandedBarDatum['status']) => {
+  switch (status) {
+    case 'Satisfactory':
+      return DSP_COLORS.SATISFACTORY;
+    case 'Average':
+      return DSP_COLORS.AVERAGE;
+    default:
+      return DSP_COLORS.UNSATISFACTORY;
+  }
+};
+
+const renderLabel = (props: any, labelMode: LabelMode) => {
+  const { x, y, width, height, value } = props; // value depends on Bar
+  const text = labelMode === 'percent' ? `${props.payload.percentage.toFixed(1)}%` : `${value.toLocaleString?.() ?? value}`;
+  const fitsInside = width > 28;
+  const tx = fitsInside ? x + width - 4 : x + width + 4;
+  const anchor = fitsInside ? 'end' : 'start';
+  const fill = fitsInside ? '#fff' : 'rgba(255,255,255,0.85)';
+  return (
+    <text x={tx} y={y + height / 2} textAnchor={anchor} dominantBaseline="central" fill={fill} fontSize={12} fontWeight={600}>
+      {text}
+    </text>
+  );
+};
+
+const ExpandedBarChart: React.FC<ExpandedBarChartProps> = ({ data, labelMode }) => {
+  // Prepare for stacked overlay: black bar for base, colored for actual/resolved
+  const rechartsData = data.map((d) => ({
+    city: d.city,
+    base: d.raisedOrTarget,
+    value: d.actualOrResolved,
+    percentage: d.percentage,
+    status: d.status,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={rechartsData} margin={{ top: 12, right: 24, left: 12, bottom: 24 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="city" angle={-15} textAnchor="end" height={50} />
+        <YAxis />
+        <Tooltip formatter={(value: any, name: any, props: any) => [
+          value,
+          name,
+          props?.payload ? { city: props.payload.city, percentage: `${props.payload.percentage.toFixed(1)}%`, status: props.payload.status } : undefined,
+        ]} />
+        <Bar dataKey="base" name="Target/Raised" fill={DSP_COLORS.RAISED} radius={[6, 6, 0, 0]} />
+        <Bar dataKey="value" name="Actual/Resolved" radius={[6, 6, 0, 0]} fillOpacity={1}>
+          {rechartsData.map((row, idx) => (
+            <Cell key={`c-${idx}`} fill={getColor(row.status)} />
+          ))}
+          <LabelList dataKey={labelMode === 'percent' ? 'value' : 'value'} content={(p) => renderLabel(p, labelMode)} />
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default ExpandedBarChart;

--- a/src/pages/LandingPage/Charts/MicroBulletBars.tsx
+++ b/src/pages/LandingPage/Charts/MicroBulletBars.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { DSP_COLORS } from '../../../utils/constants';
+
+export interface MicroBulletDatum {
+  id: string;
+  label: string; // city
+  track: number; // e.g., raised/target
+  fill: number; // e.g., resolved/actual
+  percentage: number; // 0-100
+  status: 'Satisfactory' | 'Average' | 'Unsatisfactory';
+}
+
+export interface MicroBulletBarsProps {
+  data: MicroBulletDatum[];
+  heightPerRow?: number; // default 36
+}
+
+const getStatusColor = (status: MicroBulletDatum['status']): string => {
+  switch (status) {
+    case 'Satisfactory':
+      return DSP_COLORS.SATISFACTORY;
+    case 'Average':
+      return DSP_COLORS.AVERAGE;
+    default:
+      return DSP_COLORS.UNSATISFACTORY;
+  }
+};
+
+const MicroBulletBars: React.FC<MicroBulletBarsProps> = ({ data, heightPerRow = 36 }) => {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+      {data.map((d) => {
+        const color = getStatusColor(d.status);
+        const safePct = isFinite(d.percentage) ? Math.max(0, Math.min(100, d.percentage)) : 0;
+        const showInside = safePct >= 28; // inside badge if wide enough
+        return (
+          <Box key={d.id} sx={{ minHeight: heightPerRow }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.5, gap: 1 }}>
+              <Typography variant="body2" sx={{ color: 'text.primary', fontWeight: 500, minWidth: 140 }}>
+                {d.label}
+              </Typography>
+              {/* Right-side textual summary: just percentage per user request */}
+              <Typography variant="caption" sx={{ color: color, fontWeight: 700 }}>
+                {safePct.toFixed(1)}%
+              </Typography>
+            </Box>
+
+            <Box sx={{ position: 'relative', height: 18, width: '100%', borderRadius: 9, backgroundColor: 'rgba(255,255,255,0.08)', overflow: 'hidden' }}>
+              {/* Track not directly rendered numerically since we only show %; we still use track for semantics */}
+              <Box
+                sx={{
+                  position: 'absolute',
+                  left: 0,
+                  top: 0,
+                  height: '100%',
+                  width: `${safePct}%`,
+                  background: `linear-gradient(90deg, ${color} 0%, ${color}CC 100%)`,
+                  borderRadius: 9,
+                  transition: 'width 0.6s ease',
+                  boxShadow: `0 0 10px ${color}40, inset 0 1px 0 rgba(255,255,255,0.15)`,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'flex-end',
+                  pr: 1,
+                }}
+              >
+                {showInside && (
+                  <Typography variant="caption" sx={{ color: '#fff', fontWeight: 700 }}>
+                    {d.status}
+                  </Typography>
+                )}
+              </Box>
+
+              {!showInside && (
+                <Box sx={{ position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)' }}>
+                  <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.7)', fontWeight: 600 }}>
+                    {d.status}
+                  </Typography>
+                </Box>
+              )}
+            </Box>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+};
+
+export default MicroBulletBars;

--- a/src/pages/LandingPage/Charts/exportUtils.ts
+++ b/src/pages/LandingPage/Charts/exportUtils.ts
@@ -1,0 +1,53 @@
+export function exportRowsToCSV(filename: string, rows: any[]) {
+  const headers = rows.length ? Object.keys(rows[0]) : [];
+  const csv = [headers.join(','), ...rows.map((r) => headers.map((h) => JSON.stringify((r as any)[h] ?? '')).join(','))].join('\n');
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const link = document.createElement('a');
+  const url = URL.createObjectURL(blob);
+  link.setAttribute('href', url);
+  link.setAttribute('download', filename);
+  link.style.visibility = 'hidden';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+// Export a container containing SVG (e.g., Recharts) to PNG
+export async function exportSVGContainerToPNG(container: HTMLElement, filename: string) {
+  const svg = container.querySelector('svg');
+  if (!svg) return;
+
+  const svgData = new XMLSerializer().serializeToString(svg);
+  const svgBlob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(svgBlob);
+
+  const img = new Image();
+  const loaded = await new Promise<HTMLImageElement>((resolve) => {
+    img.onload = () => resolve(img);
+    img.src = url;
+  });
+
+  const bbox = svg.getBoundingClientRect();
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.max(1, Math.floor(bbox.width));
+  canvas.height = Math.max(1, Math.floor(bbox.height));
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  ctx.fillStyle = getComputedStyle(container).backgroundColor || '#ffffff';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.drawImage(loaded, 0, 0);
+
+  canvas.toBlob((blob) => {
+    if (!blob) return;
+    const a = document.createElement('a');
+    const url2 = URL.createObjectURL(blob);
+    a.href = url2;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url2);
+  }, 'image/png');
+
+  URL.revokeObjectURL(url);
+}

--- a/src/pages/LandingPage/StatsOverview.tsx
+++ b/src/pages/LandingPage/StatsOverview.tsx
@@ -1,21 +1,5 @@
-import React from 'react';
-import {
-  Box,
-  Container,
-  Typography,
-  Grid,
-  Card,
-  CardContent,
-} from '@mui/material';
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-} from 'recharts';
+import React, { useMemo, useRef, useState } from 'react';
+import { Box, Container, Typography, Grid } from '@mui/material';
 import { DSP_COLORS } from '../../utils/constants';
 import {
   DSPComplaintData,
@@ -23,6 +7,11 @@ import {
   MRSUsageData,
   ProgramOverviewData,
 } from '../../types';
+import ChartCard from './Charts/ChartCard';
+import MicroBulletBars, { MicroBulletDatum } from './Charts/MicroBulletBars';
+import ExpandChartDialog, { LabelMode } from './Charts/ExpandChartDialog';
+import ExpandedBarChart, { ExpandedBarDatum } from './Charts/ExpandedBarChart';
+import { exportRowsToCSV, exportSVGContainerToPNG } from './Charts/exportUtils';
 
 // Color constants matching tile styles (use shared DSP_COLORS)
 const COLORS = {
@@ -180,129 +169,188 @@ const mockData: ProgramOverviewData = {
   ],
 };
 
-// DSP Section Component
-const DSPSection: React.FC<{ data: DSPComplaintData[] }> = ({ data }) => {
-  // Transform data for recharts with separate columns for each status
-  const chartData = data.map((item) => ({
-    city: item.city,
-    raised: item.raised,
-    resolvedSatisfactory: item.status === 'Satisfactory' ? item.resolved : 0,
-    resolvedAverage: item.status === 'Average' ? item.resolved : 0,
-    resolvedUnsatisfactory: item.status === 'Unsatisfactory' ? item.resolved : 0,
-  }));
+// Section components render micro bars and provide expand action
+const DSPSection: React.FC<{
+  data: DSPComplaintData[];
+  onExpand: (expanded: { title: string; rows: any[]; chart: ExpandedBarDatum[] }) => void;
+}> = ({ data, onExpand }) => {
+  const microData: MicroBulletDatum[] = useMemo(
+    () =>
+      data.map((item, i) => ({
+        id: `${i}-${item.city}`,
+        label: item.city,
+        track: item.raised,
+        fill: item.resolved,
+        percentage: item.resolutionPercentage,
+        status: item.status,
+      })),
+    [data]
+  );
 
-  
+  const expandedChart: ExpandedBarDatum[] = useMemo(
+    () =>
+      data.map((item) => ({
+        city: item.city,
+        raisedOrTarget: item.raised,
+        actualOrResolved: item.resolved,
+        percentage: item.resolutionPercentage,
+        status: item.status,
+      })),
+    [data]
+  );
+
+  const csvRows = useMemo(
+    () =>
+      data.map((d) => ({
+        City: d.city,
+        Raised: d.raised,
+        Resolved: d.resolved,
+        ResolutionPercentage: d.resolutionPercentage.toFixed(1),
+        Status: d.status,
+      })),
+    [data]
+  );
 
   return (
-    <Card sx={{ height: '100%', backgroundColor: 'background.paper' }}>
-      <CardContent>
-        <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
-          Complaint Status: Road repairs & Civic Infra
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Actual Raise Vs Actual Resolved
-        </Typography>
-        <Box sx={{ height: 260 }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={chartData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="city" />
-              <YAxis />
-              <Tooltip />
-              <Bar dataKey="raised" fill={COLORS.BLACK} name="Raised" />
-              <Bar dataKey="resolvedSatisfactory" fill={COLORS.SATISFACTORY} name="Resolved (Satisfactory)" stackId="resolved" />
-              <Bar dataKey="resolvedAverage" fill={COLORS.AVERAGE} name="Resolved (Average)" stackId="resolved" />
-              <Bar dataKey="resolvedUnsatisfactory" fill={COLORS.UNSATISFACTORY} name="Resolved (Unsatisfactory)" stackId="resolved" />
-            </BarChart>
-          </ResponsiveContainer>
-        </Box>
-
-        
-      </CardContent>
-    </Card>
+    <ChartCard
+      title="Complaint Status: Road repairs & Civic Infra"
+      subtitle="Percent resolved"
+      onExpand={() => onExpand({ title: 'DSP — Complaints Resolved', rows: csvRows, chart: expandedChart })}
+    >
+      <MicroBulletBars data={microData} />
+    </ChartCard>
   );
 };
 
 // C&D Section Component
-const CDSection: React.FC<{ data: CDCollectionData[] }> = ({ data }) => {
-  // Transform data for recharts with separate columns for each status
-  const chartData = data.map((item) => ({
-    city: item.city,
-    target: item.target,
-    actualSatisfactory: item.status === 'Satisfactory' ? item.actual : 0,
-    actualAverage: item.status === 'Average' ? item.actual : 0,
-    actualUnsatisfactory: item.status === 'Unsatisfactory' ? item.actual : 0,
-  }));
+const CDSection: React.FC<{
+  data: CDCollectionData[];
+  onExpand: (expanded: { title: string; rows: any[]; chart: ExpandedBarDatum[] }) => void;
+}> = ({ data, onExpand }) => {
+  const microData: MicroBulletDatum[] = useMemo(
+    () =>
+      data.map((item, i) => ({
+        id: `${i}-${item.city}`,
+        label: item.city,
+        track: item.target,
+        fill: item.actual,
+        percentage: item.achievementPercentage,
+        status: item.status,
+      })),
+    [data]
+  );
+
+  const expandedChart: ExpandedBarDatum[] = useMemo(
+    () =>
+      data.map((item) => ({
+        city: item.city,
+        raisedOrTarget: item.target,
+        actualOrResolved: item.actual,
+        percentage: item.achievementPercentage,
+        status: item.status,
+      })),
+    [data]
+  );
+
+  const csvRows = useMemo(
+    () =>
+      data.map((d) => ({
+        City: d.city,
+        Target: d.target,
+        Actual: d.actual,
+        AchievementPercentage: d.achievementPercentage.toFixed(1),
+        Status: d.status,
+      })),
+    [data]
+  );
 
   return (
-    <Card sx={{ height: '100%', backgroundColor: 'background.paper' }}>
-      <CardContent>
-        <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
-          Citywise C&D Collection Status
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Target Vs Actual
-        </Typography>
-        <Box sx={{ height: 260 }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={chartData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="city" />
-              <YAxis />
-              <Tooltip />
-              <Bar dataKey="target" fill={COLORS.BLACK} name="Target" />
-              <Bar dataKey="actualSatisfactory" fill={COLORS.SATISFACTORY} name="Actuals (Satisfactory)" stackId="actual" />
-              <Bar dataKey="actualAverage" fill={COLORS.AVERAGE} name="Actuals (Average)" stackId="actual" />
-              <Bar dataKey="actualUnsatisfactory" fill={COLORS.UNSATISFACTORY} name="Actuals (Unsatisfactory)" stackId="actual" />
-            </BarChart>
-          </ResponsiveContainer>
-        </Box>
-      </CardContent>
-    </Card>
+    <ChartCard
+      title="Citywise C&D Collection Status"
+      subtitle="Percent achieved"
+      onExpand={() => onExpand({ title: 'C&D — Collection Achievement', rows: csvRows, chart: expandedChart })}
+    >
+      <MicroBulletBars data={microData} />
+    </ChartCard>
   );
 };
 
 // MRS Section Component
-const MRSSection: React.FC<{ data: MRSUsageData[] }> = ({ data }) => {
-  // Transform data for recharts with separate columns for each status
-  const chartData = data.map((item) => ({
-    city: item.city,
-    targetRoadLength: item.targetRoadLength,
-    actualSatisfactory: item.status === 'Satisfactory' ? item.actualRoadLength : 0,
-    actualAverage: item.status === 'Average' ? item.actualRoadLength : 0,
-    actualUnsatisfactory: item.status === 'Unsatisfactory' ? item.actualRoadLength : 0,
-  }));
+const MRSSection: React.FC<{
+  data: MRSUsageData[];
+  onExpand: (expanded: { title: string; rows: any[]; chart: ExpandedBarDatum[] }) => void;
+}> = ({ data, onExpand }) => {
+  const microData: MicroBulletDatum[] = useMemo(
+    () =>
+      data.map((item, i) => ({
+        id: `${i}-${item.city}`,
+        label: item.city,
+        track: item.targetRoadLength,
+        fill: item.actualRoadLength,
+        percentage: item.coveragePercentage,
+        status: item.status,
+      })),
+    [data]
+  );
+
+  const expandedChart: ExpandedBarDatum[] = useMemo(
+    () =>
+      data.map((item) => ({
+        city: item.city,
+        raisedOrTarget: item.targetRoadLength,
+        actualOrResolved: item.actualRoadLength,
+        percentage: item.coveragePercentage,
+        status: item.status,
+      })),
+    [data]
+  );
+
+  const csvRows = useMemo(
+    () =>
+      data.map((d) => ({
+        City: d.city,
+        TargetRoadLength: d.targetRoadLength,
+        ActualRoadLength: d.actualRoadLength,
+        CoveragePercentage: d.coveragePercentage.toFixed(1),
+        Status: d.status,
+      })),
+    [data]
+  );
 
   return (
-    <Card sx={{ height: '100%', backgroundColor: 'background.paper' }}>
-      <CardContent>
-        <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
-          Citywise MRS Usage Status
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-          Target Road Length Covered to Actual Road Length Covered
-        </Typography>
-        <Box sx={{ height: 260 }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={chartData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="city" />
-              <YAxis />
-              <Tooltip />
-              <Bar dataKey="targetRoadLength" fill={COLORS.BLACK} name="Target" />
-              <Bar dataKey="actualSatisfactory" fill={COLORS.SATISFACTORY} name="Actuals (Satisfactory)" stackId="actual" />
-              <Bar dataKey="actualAverage" fill={COLORS.AVERAGE} name="Actuals (Average)" stackId="actual" />
-              <Bar dataKey="actualUnsatisfactory" fill={COLORS.UNSATISFACTORY} name="Actuals (Unsatisfactory)" stackId="actual" />
-            </BarChart>
-          </ResponsiveContainer>
-        </Box>
-      </CardContent>
-    </Card>
+    <ChartCard
+      title="Citywise MRS Usage Status"
+      subtitle="Percent road length covered"
+      onExpand={() => onExpand({ title: 'MRS — Road Coverage', rows: csvRows, chart: expandedChart })}
+    >
+      <MicroBulletBars data={microData} />
+    </ChartCard>
   );
 };
 
 // Main StatsOverview Component
 const StatsOverview: React.FC = () => {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [labelMode, setLabelMode] = useState<LabelMode>('percent');
+  const [dialogTitle, setDialogTitle] = useState('');
+  const [expandedData, setExpandedData] = useState<ExpandedBarDatum[]>([]);
+  const [csvRows, setCsvRows] = useState<any[]>([]);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const openExpand = (cfg: { title: string; rows: any[]; chart: ExpandedBarDatum[] }) => {
+    setDialogTitle(cfg.title);
+    setExpandedData(cfg.chart);
+    setCsvRows(cfg.rows);
+    setDialogOpen(true);
+  };
+
+  const exportCSV = () => exportRowsToCSV(`${dialogTitle.replace(/\s+/g, '_').toLowerCase()}.csv`, csvRows);
+  const exportPNG = () => {
+    if (contentRef.current) {
+      exportSVGContainerToPNG(contentRef.current, `${dialogTitle.replace(/\s+/g, '_').toLowerCase()}.png`);
+    }
+  };
+
   return (
     <Container maxWidth="xl" sx={{ py: 3, position: 'relative' }}>
       <Typography
@@ -326,17 +374,17 @@ const StatsOverview: React.FC = () => {
       <Grid container spacing={3}>
         {/* DSP Section */}
         <Grid item xs={12} lg={4}>
-          <DSPSection data={mockData.dspData} />
+          <DSPSection data={mockData.dspData} onExpand={openExpand} />
         </Grid>
         
         {/* C&D Section */}
         <Grid item xs={12} lg={4}>
-          <CDSection data={mockData.cdData} />
+          <CDSection data={mockData.cdData} onExpand={openExpand} />
         </Grid>
         
         {/* MRS Section */}
         <Grid item xs={12} lg={4}>
-          <MRSSection data={mockData.mrsData} />
+          <MRSSection data={mockData.mrsData} onExpand={openExpand} />
         </Grid>
       </Grid>
 
@@ -381,6 +429,19 @@ const StatsOverview: React.FC = () => {
           </Box>
         </Box>
       </Box>
+      <ExpandChartDialog
+        open={dialogOpen}
+        title={dialogTitle}
+        onClose={() => setDialogOpen(false)}
+        onExportCSV={exportCSV}
+        onExportPNG={exportPNG}
+        labelMode={labelMode}
+        onLabelModeChange={setLabelMode}
+        contentRef={contentRef}
+      >
+        <ExpandedBarChart data={expandedData} labelMode={labelMode} />
+      </ExpandChartDialog>
+
     </Container>
   );
 };


### PR DESCRIPTION
Introduce compact, readable micro charts on the landing page with an expand-to-modal feature, ensuring all labels are visible and enabling CSV/PNG export.

---
<a href="https://cursor.com/background-agent?bcId=bc-70334029-553b-4052-8c61-f3d2a7c15fa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-70334029-553b-4052-8c61-f3d2a7c15fa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

