### PR TITLE
Format chart bar labels and add background

### DIFF
--- a/src/pages/LandingPage/Charts/ExpandedBarChart.tsx
+++ b/src/pages/LandingPage/Charts/ExpandedBarChart.tsx
@@ -36,7 +36,7 @@ const renderLabel = (props: any, labelMode: LabelMode) => {
   const isAverage = payload?.status === 'Average';
   const fill = fitsInside ? (isAverage ? '#000000' : '#ffffff') : (isAverage ? '#000000' : 'rgba(255,255,255,0.85)');
   return (
-    <text x={tx} y={y + height / 2} textAnchor={anchor} dominantBaseline="central" fill={fill} fontSize={12} fontWeight={700}>
+    <text x={tx} y={y + height / 2} textAnchor={anchor} dominantBaseline="central" fill={fill} fontSize={12} fontWeight={400}>
       {text}
     </text>
   );

--- a/src/pages/LandingPage/Charts/MicroBulletBars.tsx
+++ b/src/pages/LandingPage/Charts/MicroBulletBars.tsx
@@ -43,21 +43,7 @@ const MicroBulletBars: React.FC<MicroBulletBarsProps> = ({ data, heightPerRow = 
               <Typography variant="body2" sx={{ color: 'text.primary', fontWeight: 500, minWidth: 140 }}>
                 {d.label}
               </Typography>
-              {/* Status chip moved to the left of the bar (visual alignment hint) */}
-              <Typography
-                variant="caption"
-                sx={{
-                  px: 1,
-                  py: 0.25,
-                  borderRadius: 1,
-                  fontWeight: 700,
-                  bgcolor: `${color}33`,
-                  color: isAverage ? '#000000' : color,
-                  border: `1px solid ${color}66`,
-                }}
-              >
-                {d.status}
-              </Typography>
+              {/* Status chip removed per latest requirement: status will be on the bar itself */}
             </Box>
 
             <Box
@@ -66,7 +52,8 @@ const MicroBulletBars: React.FC<MicroBulletBarsProps> = ({ data, heightPerRow = 
                 height: 20,
                 width: '100%',
                 borderRadius: 10,
-                backgroundColor: 'rgba(255,255,255,0.08)',
+                // Stronger grey track behind the filled bar (superimposed look)
+                backgroundColor: '#9EA7B333',
                 overflow: 'hidden',
               }}
             >
@@ -85,17 +72,39 @@ const MicroBulletBars: React.FC<MicroBulletBarsProps> = ({ data, heightPerRow = 
                 }}
               />
 
-              {/* Percentage label on the bar */}
+              {/* Status label inside the filled bar, aligned to the left */}
+              <Typography
+                variant="caption"
+                sx={{
+                  position: 'absolute',
+                  left: 8,
+                  top: '50%',
+                  transform: 'translateY(-50%)',
+                  color: labelTextColor,
+                  fontWeight: 600,
+                  pointerEvents: 'none',
+                  whiteSpace: 'nowrap',
+                  textOverflow: 'ellipsis',
+                  overflow: 'hidden',
+                  maxWidth: `${safePct}%`,
+                }}
+              >
+                {d.status}
+              </Typography>
+
+              {/* Percentage label inside the filled bar, aligned to the right; unbolded */}
               {showInside ? (
                 <Typography
                   variant="caption"
                   sx={{
                     position: 'absolute',
-                    right: Math.max(4, 100 - safePct < 6 ? 4 : 8),
+                    right: 8,
                     top: '50%',
                     transform: 'translateY(-50%)',
                     color: labelTextColor,
-                    fontWeight: 800,
+                    fontWeight: 400,
+                    pointerEvents: 'none',
+                    whiteSpace: 'nowrap',
                   }}
                 >
                   {safePct.toFixed(1)}%
@@ -110,7 +119,8 @@ const MicroBulletBars: React.FC<MicroBulletBarsProps> = ({ data, heightPerRow = 
                     top: '50%',
                     transform: 'translateY(-50%)',
                     color: outsideTextColor,
-                    fontWeight: 800,
+                    fontWeight: 400,
+                    pointerEvents: 'none',
                   }}
                 >
                   {safePct.toFixed(1)}%


### PR DESCRIPTION
Update bar charts to display status and unbolded percentages inside the bars, superimposed on a grey track, as per user's visual specifications.

---
<a href="https://cursor.com/background-agent?bcId=bc-dbfcef03-d975-4e44-acc0-86076d69e4cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dbfcef03-d975-4e44-acc0-86076d69e4cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

