### PR TITLE
Fix chart display and window centering

### DIFF
--- a/src/pages/LandingPage/Charts/ExpandChartDialog.tsx
+++ b/src/pages/LandingPage/Charts/ExpandChartDialog.tsx
@@ -40,7 +40,22 @@ const ExpandChartDialog: React.FC<ExpandChartDialogProps> = ({
   contentRef,
 }) => {
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="lg" aria-labelledby="expanded-chart-title">
+    <Dialog 
+      open={open} 
+      onClose={onClose} 
+      fullWidth 
+      maxWidth="lg" 
+      aria-labelledby="expanded-chart-title"
+      sx={{
+        '& .MuiDialog-container': {
+          alignItems: 'center',
+          justifyContent: 'center',
+        },
+        '& .MuiPaper-root': {
+          margin: 0, // remove default margin that can offset from center
+        },
+      }}
+    >
       <DialogTitle id="expanded-chart-title" sx={{ pr: 6 }}>
         {title}
         <IconButton onClick={onClose} aria-label="close" sx={{ position: 'absolute', right: 8, top: 8 }}>

--- a/src/pages/LandingPage/Charts/MicroBulletBars.tsx
+++ b/src/pages/LandingPage/Charts/MicroBulletBars.tsx
@@ -33,7 +33,7 @@ const MicroBulletBars: React.FC<MicroBulletBarsProps> = ({ data, heightPerRow = 
       {data.map((d) => {
         const color = getStatusColor(d.status);
         const safePct = isFinite(d.percentage) ? Math.max(0, Math.min(100, d.percentage)) : 0;
-        const showInside = safePct >= 22; // lower threshold so more labels appear inside
+        const showInside = safePct >= 12; // show inside more aggressively so percentages appear on the bar
         const isAverage = d.status === 'Average';
         const labelTextColor = isAverage ? '#000000' : '#ffffff';
         const outsideTextColor = isAverage ? '#000000' : 'rgba(255,255,255,0.85)';
@@ -92,7 +92,7 @@ const MicroBulletBars: React.FC<MicroBulletBarsProps> = ({ data, heightPerRow = 
                 {d.status}
               </Typography>
 
-              {/* Percentage label inside the filled bar, aligned to the right; unbolded */}
+              {/* Percentage label placed on the bar; if bar is too thin, place slightly outside but overlapping */}
               {showInside ? (
                 <Typography
                   variant="caption"
@@ -114,10 +114,10 @@ const MicroBulletBars: React.FC<MicroBulletBarsProps> = ({ data, heightPerRow = 
                   variant="caption"
                   sx={{
                     position: 'absolute',
-                    left: `${safePct}%`,
-                    ml: 0.75,
+                    left: `calc(${safePct}% - 4px)`,
+                    // slight negative translate so text hugs the bar end and appears on it
+                    transform: 'translate(-100%, -50%)',
                     top: '50%',
-                    transform: 'translateY(-50%)',
                     color: outsideTextColor,
                     fontWeight: 400,
                     pointerEvents: 'none',


### PR DESCRIPTION
Display percentages directly on micro bullet bars and center the expanded chart dialog.

---
<a href="https://cursor.com/background-agent?bcId=bc-09efecd6-2556-4344-8dea-b35fb12efff4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-09efecd6-2556-4344-8dea-b35fb12efff4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

