### PR TITLE
Update chart bar color to #363636

### DIFF
--- a/src/pages/DSP/CategoryBarChart.tsx
+++ b/src/pages/DSP/CategoryBarChart.tsx
@@ -131,7 +131,7 @@ const CategoryBarChart: React.FC<CategoryBarChartProps> = ({ data, cityName }) =
                   position: 'relative',
                   height: '22px',
                   width: '100%',
-                  backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                  backgroundColor: '#363636',
                   borderRadius: '11px',
                   overflow: 'hidden',
                   boxShadow: 'inset 0 2px 4px rgba(0,0,0,0.2)',

--- a/src/pages/LandingPage/Charts/MicroBulletBars.tsx
+++ b/src/pages/LandingPage/Charts/MicroBulletBars.tsx
@@ -53,7 +53,7 @@ const MicroBulletBars: React.FC<MicroBulletBarsProps> = ({ data, heightPerRow = 
                 width: '100%',
                 borderRadius: 10,
                 // Stronger grey track behind the filled bar (superimposed look)
-                backgroundColor: '#9EA7B333',
+                backgroundColor: '#363636',
                 overflow: 'hidden',
               }}
             >


### PR DESCRIPTION
Update chart bar background colors to `#363636` as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-5222d5a3-3fe9-4cbe-99a0-69ee5c4ac186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5222d5a3-3fe9-4cbe-99a0-69ee5c4ac186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

