### PR TITLE
Add shadow and improve text visibility on performance tiles

### DIFF
--- a/src/pages/DSP/CityTiles.tsx
+++ b/src/pages/DSP/CityTiles.tsx
@@ -679,7 +679,7 @@ const CityTiles: React.FC = () => {
             }
           }}>
             <CardContent sx={{ textAlign: 'center', py: 4, position: 'relative', zIndex: 1 }}>
-              <Typography variant="h4" sx={(theme) => ({ fontWeight: 800, mb: 4, color: theme.palette.mode === 'dark' ? '#ffffff' : theme.palette.text.primary, textShadow: theme.palette.mode === 'dark' ? '0 2px 4px rgba(0,0,0,0.3)' : 'none' })}>
+              <Typography variant="h4" sx={(theme) => ({ fontWeight: 800, mb: 4, color: theme.palette.mode === 'dark' ? '#ffffff' : '#000000', textShadow: theme.palette.mode === 'dark' ? '0 2px 4px rgba(0,0,0,0.3)' : '0 1px 2px rgba(0,0,0,0.25)' })}>
                 Overall Delhi NCR Performance
               </Typography>
               
@@ -716,10 +716,10 @@ const CityTiles: React.FC = () => {
               boxShadow: '0 8px 32px rgba(0,0,0,0.1)',
             }}>
               <CardContent sx={{ py: 3 }}>
-                <Typography variant="h4" sx={(theme) => ({ fontWeight: 800, color: theme.palette.mode === 'dark' ? '#ffffff' : theme.palette.text.primary, textShadow: theme.palette.mode === 'dark' ? '0 2px 4px rgba(0,0,0,0.3)' : 'none' })}>
+                <Typography variant="h4" sx={(theme) => ({ fontWeight: 800, color: theme.palette.mode === 'dark' ? '#ffffff' : '#000000', textShadow: theme.palette.mode === 'dark' ? '0 2px 4px rgba(0,0,0,0.3)' : '0 1px 2px rgba(0,0,0,0.25)' })}>
                   {totalCities}
                 </Typography>
-                <Typography variant="body2" sx={(theme) => ({ color: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.7)' : 'rgba(0, 0, 0, 0.7)', fontWeight: 500 })}>
+                <Typography variant="body2" sx={(theme) => ({ color: theme.palette.mode === 'dark' ? 'rgba(255, 255, 255, 0.7)' : '#000000', fontWeight: 500 })}>
                   Total Cities
                 </Typography>
               </CardContent>


### PR DESCRIPTION
Enhance readability of "Overall Delhi NCR Performance" and "Total Cities" tiles by adding text shadows and forcing black text in light mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-d07ce679-84dd-44dc-b605-71af73cd923e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d07ce679-84dd-44dc-b605-71af73cd923e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

