### PR TITLE
Shrink chart assets by twenty five percent

### DIFF
--- a/src/pages/DSP/CategoryBarChart.tsx
+++ b/src/pages/DSP/CategoryBarChart.tsx
@@ -58,6 +58,7 @@ interface ProcessedRow extends CategoryData {
 }
 
 const CategoryBarChart: React.FC<CategoryBarChartProps> = ({ data, cityName }) => {
+  const DISPLAY_SCALE = 0.75; // scale down visual size by 25%
   // Display tuning constants
   const AGGREGATION_THRESHOLD = 0.025; // 2.5%
   const MAX_SLICES_VISIBLE = 8; // cap visible slices for readability
@@ -177,7 +178,7 @@ const CategoryBarChart: React.FC<CategoryBarChartProps> = ({ data, cityName }) =
   const DonutView = (
     <Box sx={{ display: 'flex', gap: 2, alignItems: 'stretch', flexWrap: { xs: 'wrap', md: 'nowrap' } }}>
       <Box ref={chartBoxRef} sx={{ flex: '1 1 340px', minWidth: 320, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>        
+        <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} style={{ transform: `scale(${DISPLAY_SCALE})`, transformOrigin: 'center' }}>
           {/* Outer ring background */}
           <circle cx={center} cy={center} r={outerR} fill="none" stroke="rgba(255,255,255,0.08)" strokeWidth={ringThickness} />
           {/* Inner ring background */}
@@ -244,7 +245,7 @@ const CategoryBarChart: React.FC<CategoryBarChartProps> = ({ data, cityName }) =
       </Box>
 
       {/* Legend */}
-      <Box sx={{ flex: '1 1 260px', minWidth: 240, maxHeight: size, overflow: 'auto', pr: 1 }}>
+      <Box sx={{ flex: '1 1 260px', minWidth: 240, maxHeight: Math.floor(size * DISPLAY_SCALE), overflow: 'auto', pr: 1 }}>
         <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.85)', mb: 1, textAlign: 'center' }}>
           Raised vs Resolved by Category
         </Typography>

--- a/src/pages/DSP/CityTiles.tsx
+++ b/src/pages/DSP/CityTiles.tsx
@@ -115,7 +115,7 @@ const StatusChip = styled(Chip, {
 const CircularProgressIndicator: React.FC<{ percentage: number; color: string; size?: number }> = ({ 
   percentage, 
   color, 
-  size = 120 
+  size = 90 
 }) => {
   return (
     <Box sx={{ position: 'relative', display: 'inline-flex' }}>
@@ -196,7 +196,7 @@ const ConsolidatedGaugeChart: React.FC<{
   raisedValue: number; 
   resolvedValue: number; 
   size?: number 
-}> = ({ raisedValue, resolvedValue, size = 260 }) => {
+}> = ({ raisedValue, resolvedValue, size = 195 }) => {
   const resolutionRate = raisedValue > 0 ? Math.min((resolvedValue / raisedValue) * 100, 100) : 0;
 
   // Fixed color for Raised ring (brand blue)
@@ -370,7 +370,7 @@ const CityTile: React.FC<CityTileProps> = ({ city, onMoreInfo }) => {
               <CircularProgressIndicator 
                 percentage={city.resolutionPercentage}
                 color={resolutionColor}
-                size={92}
+                size={69}
               />
             </Box>
 
@@ -504,7 +504,7 @@ const CityDetailsDialog: React.FC<CityDetailsDialogProps> = ({ city, open, onClo
               <CircularProgressIndicator 
                 percentage={city.resolutionPercentage}
                 color={resolutionColor}
-                size={100}
+                size={75}
               />
             </Box>
           </Grid>
@@ -688,7 +688,7 @@ const CityTiles: React.FC = () => {
                 <ConsolidatedGaugeChart
                   raisedValue={totalRaised}
                   resolvedValue={totalResolved}
-                  size={200}
+                  size={150}
                 />
               </Box>
               

--- a/src/pages/LandingPage/Charts/ExpandChartDialog.tsx
+++ b/src/pages/LandingPage/Charts/ExpandChartDialog.tsx
@@ -87,7 +87,7 @@ const ExpandChartDialog: React.FC<ExpandChartDialogProps> = ({
             )}
           </Box>
         </Box>
-        <Box ref={contentRef} sx={{ height: 460 }}>
+        <Box ref={contentRef} sx={{ height: 345 }}>
           {children}
         </Box>
       </DialogContent>

--- a/src/pages/LandingPage/Charts/MicroBulletBars.tsx
+++ b/src/pages/LandingPage/Charts/MicroBulletBars.tsx
@@ -13,7 +13,7 @@ export interface MicroBulletDatum {
 
 export interface MicroBulletBarsProps {
   data: MicroBulletDatum[];
-  heightPerRow?: number; // default 36
+  heightPerRow?: number; // default 27 (25% smaller)
 }
 
 const getStatusColor = (status: MicroBulletDatum['status']): string => {
@@ -27,7 +27,7 @@ const getStatusColor = (status: MicroBulletDatum['status']): string => {
   }
 };
 
-const MicroBulletBars: React.FC<MicroBulletBarsProps> = ({ data, heightPerRow = 36 }) => {
+const MicroBulletBars: React.FC<MicroBulletBarsProps> = ({ data, heightPerRow = 27 }) => {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
       {data.map((d) => {
@@ -49,7 +49,7 @@ const MicroBulletBars: React.FC<MicroBulletBarsProps> = ({ data, heightPerRow = 
             <Box
               sx={{
                 position: 'relative',
-                height: 20,
+                height: 15,
                 width: '100%',
                 borderRadius: 10,
                 // Stronger grey track behind the filled bar (superimposed look)

--- a/src/pages/LandingPage/HeroSection.tsx
+++ b/src/pages/LandingPage/HeroSection.tsx
@@ -106,7 +106,7 @@ const CircularProgressIndicator: React.FC<{
   percentage: number;
   color: string;
   size?: number;
-}> = ({ percentage, color, size = 92 }) => {
+}> = ({ percentage, color, size = 69 }) => {
   return (
     <Box sx={{ position: 'relative', display: 'inline-flex' }}>
       <CircularProgress


### PR DESCRIPTION
Reduce chart sizes by 25% across various components as requested.

This was achieved by:
- Scaling the donut chart with a CSS transform and adjusting legend height in `CategoryBarChart.tsx`.
- Reducing the expanded dialog content area height in `ExpandChartDialog.tsx`.
- Updating default and explicit size props for gauges and circular progress indicators in `CityTiles.tsx` and `HeroSection.tsx`.
- Reducing default row and bar heights for micro bullet bars in `MicroBulletBars.tsx`.

---
<a href="https://cursor.com/background-agent?bcId=bc-8327c257-1ef2-4530-8fde-8cbf1654d431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8327c257-1ef2-4530-8fde-8cbf1654d431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

