### PR TITLE
Increase gauge ring radius

### DIFF
--- a/src/pages/DSP/CityTiles.tsx
+++ b/src/pages/DSP/CityTiles.tsx
@@ -212,7 +212,7 @@ const ConsolidatedGaugeChart: React.FC<{
   const TRACK_COLOR = 'rgba(255, 255, 255, 0.12)';
 
   const center = size / 2;
-  const outerRadius = center - 10; // outer ring padding 10
+  const outerRadius = center - 6; // outer ring padding 6
   const innerRadius = outerRadius - 14; // spacing between rings
 
   const outerCircumference = 2 * Math.PI * outerRadius;


### PR DESCRIPTION
Increase the gauge ring radius by reducing the outer padding in `ConsolidatedGaugeChart`.

---
<a href="https://cursor.com/background-agent?bcId=bc-dce53e62-0351-4004-8ec9-7a01466c7c4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dce53e62-0351-4004-8ec9-7a01466c7c4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

