### PR TITLE
Update city tile text color

### DIFF
--- a/src/pages/DSP/CategoryBarChart.tsx
+++ b/src/pages/DSP/CategoryBarChart.tsx
@@ -246,7 +246,7 @@ const CategoryBarChart: React.FC<CategoryBarChartProps> = ({ data, cityName }) =
 
       {/* Legend */}
       <Box sx={{ flex: '1 1 260px', minWidth: 240, maxHeight: Math.floor(size * DISPLAY_SCALE), overflow: 'auto', pr: 1 }}>
-        <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.85)', mb: 1, textAlign: 'center' }}>
+        <Typography variant="body2" sx={{ color: '#000000', mb: 1, textAlign: 'center' }}>
           Raised vs Resolved by Category
         </Typography>
         <Divider sx={{ mb: 1, borderColor: 'rgba(255,255,255,0.08)' }} />


### PR DESCRIPTION
Change "Raised vs Resolved by Category" text color to black to improve visibility and readability on city tiles.

---
<a href="https://cursor.com/background-agent?bcId=bc-65c6adf5-0185-48c2-a2c2-553c3c52d42b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-65c6adf5-0185-48c2-a2c2-553c3c52d42b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

