### PR TITLE
Change text color for visibility

### DIFF
--- a/src/pages/DSP/CityTiles.tsx
+++ b/src/pages/DSP/CityTiles.tsx
@@ -295,13 +295,13 @@ const ConsolidatedGaugeChart: React.FC<{
       <Box sx={{ display: 'flex', justifyContent: 'center', gap: 4, mt: 2 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.2 }}>
           <Box sx={{ width: 12, height: 12, borderRadius: '50%', background: RAISED_COLOR }} />
-          <Typography variant="body2" sx={(theme) => ({ color: theme.palette.mode === 'dark' ? '#ffffff' : theme.palette.text.primary })}>
+          <Typography variant="body2" sx={{ color: '#000000' }}>
             Issues Raised ({raisedValue.toLocaleString()})
           </Typography>
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.2 }}>
           <Box sx={{ width: 12, height: 12, borderRadius: '50%', background: RESOLVED_COLOR }} />
-          <Typography variant="body2" sx={(theme) => ({ color: theme.palette.mode === 'dark' ? '#ffffff' : theme.palette.text.primary })}>
+          <Typography variant="body2" sx={{ color: '#000000' }}>
             Issues Resolved ({resolvedValue.toLocaleString()})
           </Typography>
         </Box>


### PR DESCRIPTION
Change "Raised" and "Resolved" legend text color to black for visibility in dark mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-472c9b2e-b374-4203-a29b-fe7be1eb9a88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-472c9b2e-b374-4203-a29b-fe7be1eb9a88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

