### PR TITLE
Update dsp page labels and remove tab

### DIFF
--- a/src/pages/DSP/CityTiles.tsx
+++ b/src/pages/DSP/CityTiles.tsx
@@ -383,7 +383,7 @@ const CityTile: React.FC<CityTileProps> = ({ city, onOpen }) => {
                 letterSpacing: 0.2,
               })}
             >
-              Resolution Percentage
+              Resolution Re-Open Percentage
             </Typography>
           </Box>
 
@@ -608,12 +608,7 @@ const CityTiles: React.FC = () => {
                 />
               </Box>
 
-              {/* Action row */}
-              <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
-                <PillButton onClick={() => setConsolidatedOpen(true)} variant="contained">
-                  Category Wise
-                </PillButton>
-              </Box>
+              {/* Action row removed per requirement: no Category Wise tab */}
             </CardContent>
           </Paper>
         </Grid>


### PR DESCRIPTION
Update DSP city tiles to "Resolution Re-Open Percentage" and remove the "Category Wise" tab from "Overall Delhi NCR Performance" as per user request.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d8b78ba-47e0-4b57-9efd-8548bcf06539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3d8b78ba-47e0-4b57-9efd-8548bcf06539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated city tile gauge caption text to reflect "Resolution Re-Open Percentage"
  * Removed Category Wise button from consolidated header and its associated dialog functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->