### PR TITLE
Update city tile with radial gauge

### DIFF
--- a/src/pages/DSP/CityTiles.tsx
+++ b/src/pages/DSP/CityTiles.tsx
@@ -324,7 +324,6 @@ interface CityTileProps {
 
 const CityTile: React.FC<CityTileProps> = ({ city, onOpen }) => {
   const resolutionColor = getResolutionColor(city.resolutionPercentage);
-  const status = getResolutionStatus(city.resolutionPercentage);
 
   return (
     <Grid item xs={12} sm={6} md={4} lg={3}>

--- a/src/pages/DSP/CityTiles.tsx
+++ b/src/pages/DSP/CityTiles.tsx
@@ -340,8 +340,8 @@ const CityTile: React.FC<CityTileProps> = ({ city, onOpen }) => {
             gap: 1.25,
           }}
         >
-          {/* Header with city name and status */}
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+          {/* Header with city name and compact gauge (replacing status chip) */}
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 1 }}>
             <Typography
               variant="h6"
               sx={(theme) => ({
@@ -367,10 +367,23 @@ const CityTile: React.FC<CityTileProps> = ({ city, onOpen }) => {
             >
               {city.cityName}
             </Typography>
-            <StatusChip label={status} status={status} size="small" />
+            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', minWidth: 64 }}>
+              <CircularProgressIndicator percentage={city.resolutionPercentage} color={resolutionColor} size={52} />
+              <Typography
+                variant="caption"
+                sx={(theme) => ({
+                  mt: 0.25,
+                  color: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.8)' : 'rgba(0,0,0,0.78)',
+                  fontWeight: 600,
+                  letterSpacing: 0.2,
+                })}
+              >
+                Resolution rate
+              </Typography>
+            </Box>
           </Box>
 
-          {/* Gauge */}
+          {/* Main gauge */}
           <Box sx={{ textAlign: 'center' }}>
             <CircularProgressIndicator percentage={city.resolutionPercentage} color={resolutionColor} size={74} />
             <Typography


### PR DESCRIPTION
Replace the text status chip on DSP city tiles with a compact radial gauge showing resolution rate to improve visual design and reduce clutter.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac6404ea-92f9-4ec4-a092-df85d956b13d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ac6404ea-92f9-4ec4-a092-df85d956b13d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned the City Tiles status display by replacing the top-right status chip with a compact vertical gauge panel that includes a circular progress indicator and resolution rate caption. The header layout was adjusted to maintain proper alignment and spacing with the new gauge panel design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->